### PR TITLE
don't inject timestamps parameter

### DIFF
--- a/src/m4af.c
+++ b/src/m4af.c
@@ -223,7 +223,7 @@ void m4af_write32_at(m4af_ctx_t *ctx, int64_t pos, uint32_t value)
 }
 
 m4af_ctx_t *m4af_create(uint32_t codec, uint32_t timescale,
-                        m4af_io_callbacks_t *io, void *io_cookie)
+                        m4af_io_callbacks_t *io, void *io_cookie, int no_timestamp)
 {
     m4af_ctx_t *ctx;
     int64_t timestamp;
@@ -237,7 +237,7 @@ m4af_ctx_t *m4af_create(uint32_t codec, uint32_t timescale,
     memcpy(&ctx->io, io, sizeof(m4af_io_callbacks_t));
     ctx->io_cookie = io_cookie;
     ctx->timescale = timescale;
-    timestamp = m4af_timestamp();
+    timestamp = no_timestamp ? 0 : m4af_timestamp();
     ctx->creation_time = timestamp;
     ctx->modification_time = timestamp;
     ctx->num_tracks = 1;

--- a/src/m4af.h
+++ b/src/m4af.h
@@ -75,7 +75,7 @@ typedef struct m4af_ctx_t m4af_ctx_t;
 
 
 m4af_ctx_t *m4af_create(uint32_t codec, uint32_t timescale,
-                        m4af_io_callbacks_t *io, void *io_cookie);
+                        m4af_io_callbacks_t *io, void *io_cookie, int no_timestamp);
 
 int m4af_begin_write(m4af_ctx_t *ctx);
 


### PR DESCRIPTION
It's more like technical stuff, for instance, to compare converted files which were made using differently compiled converters. I myself compare results from _cross-mingw 7.3.0_ vs _cross-mingw 8.2.0_ vs _native mingw 7.4.0_ just to be sure that _mingw_ actually works as it should. Timestamps are the only thing that prevent direct or via md5 comparison.