### PR TITLE
Fix Wstringop-overflow Warning in GCC 10

### DIFF
--- a/src/pcm_readhelper.c
+++ b/src/pcm_readhelper.c
@@ -228,7 +228,7 @@ int apple_chan_chunk(pcm_io_context_t *io, uint32_t chunk_size,
         TRY_IO(pcm_skip(io, chunk_size - 12));
         fmt->channel_mask = mChannelBitmap;
         for (i = 0; i < nchannels; ++i)
-            mapping[i] = i;
+            mapping[] = i;
         return 0;
     case kAudioChannelLayoutTag_UseChannelDescriptions:
         ENSURE(mNumberChannelDescriptions == nchannels);

--- a/src/pcm_readhelper.c
+++ b/src/pcm_readhelper.c
@@ -211,9 +211,10 @@ int apple_chan_chunk(pcm_io_context_t *io, uint32_t chunk_size,
      * Although FDK encoder supports upto 5.1ch, we handle upto
      * 8 channels here.
      */
-    uint32_t i, mChannelLayoutTag, mChannelBitmap, mNumberChannelDescriptions;
+    uint32_t mChannelLayoutTag, mChannelBitmap, mNumberChannelDescriptions;
     uint32_t mask = 0;
     const uint32_t nchannels = fmt->channels_per_frame;
+    uint32_t i[nchannels];
     uint8_t channels[9] = { 0 };
     uint8_t *index[8] = { 0 };
     const char *layout = 0;
@@ -228,7 +229,7 @@ int apple_chan_chunk(pcm_io_context_t *io, uint32_t chunk_size,
         TRY_IO(pcm_skip(io, chunk_size - 12));
         fmt->channel_mask = mChannelBitmap;
         for (i = 0; i < nchannels; ++i)
-            mapping[] = i;
+            mapping[i] = i;
         return 0;
     case kAudioChannelLayoutTag_UseChannelDescriptions:
         ENSURE(mNumberChannelDescriptions == nchannels);


### PR DESCRIPTION
There is a warning when compiling fdkaac 1.0.2 using the latest MinGW with MYSYS2.

<details>
<summary>Version info of GCC</summary>

```
$ gcc -v
Using built-in specs.
COLLECT_GCC=E:\Etc\HUGE\msys64\mingw64\bin\gcc.exe
COLLECT_LTO_WRAPPER=E:/Etc/HUGE/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.3.0/lto-wrapper.exe
Target: x86_64-w64-mingw32
Configured with: ../gcc-10.3.0/configure --prefix=/mingw64 --with-local-prefix=/mingw64/local --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --with-native-system-header-dir=/mingw64/x86_64-w64-mingw32/include --libexecdir=/mingw64/lib --enable-bootstrap --enable-checking=release --with-arch=x86-64 --with-tune=generic --enable-languages=c,lto,c++,fortran,ada,objc,obj-c++,jit --enable-shared --enable-static --enable-libatomic --enable-threads=posix --enable-graphite --enable-fully-dynamic-string --enable-libstdcxx-filesystem-ts=yes --enable-libstdcxx-time=yes --disable-libstdcxx-pch --disable-libstdcxx-debug --enable-lto --enable-libgomp --disable-multilib --disable-rpath --disable-win32-registry --disable-nls --disable-werror --disable-symvers --with-libiconv --with-system-zlib --with-gmp=/mingw64 --with-mpfr=/mingw64 --with-mpc=/mingw64 --with-isl=/mingw64 --with-pkgversion='Rev2, Built by MSYS2 project' --with-bugurl=https://github.com/msys2/MINGW-packages/issues --with-gnu-as --with-gnu-ld --with-boot-ldflags='-pipe -Wl,--dynamicbase,--high-entropy-va,--nxcompat,--default-image-base-high -Wl,--disable-dynamicbase -static-libstdc++ -static-libgcc' 'LDFLAGS_FOR_TARGET=-pipe -Wl,--dynamicbase,--high-entropy-va,--nxcompat,--default-image-base-high' --enable-linker-plugin-flags='LDFLAGS=-static-libstdc++\ -static-libgcc\ -pipe\ -Wl,--dynamicbase,--high-entropy-va,--nxcompat,--default-image-base-high\ -Wl,--stack,12582912'
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 10.3.0 (Rev2, Built by MSYS2 project)
```
</details>

The compile script is basically as follows:
```
cd fdkaac-1.0.2
autoreconf -i
CC="gcc -pipe -static-libgcc" CXX="g++ -pipe -static-libgcc" ./configure --prefix=$MINGW_PREFIX/$MINGW_CHOST/ CFLAGS="-O3 -flto -march=native"
make -j8
make install
```

During compiling, there is a warning as (full logs in https://github.com/kekyo/fdk-aac-win32-builder/issues/9#issuecomment-852979506)
```
gcc -pipe -static-libgcc  -O3 -flto -march=native   -o fdkaac.exe src/aacenc.o src/caf_reader.o src/extrapolater.o src/limiter.o src/lpc.o src/m4af.o src/main.o src/metadata.o src/parson.o src/pcm_float_converter.o src/pcm_native_converter.o src/pcm_readhelper.o src/pcm_sint16_converter.o src/progress.o src/wav_reader.o  src/compat_win32.o fdkaac.o  -liconv -lfdk-aac -lm -lfdk-aac
In function 'apple_chan_chunk',
    inlined from 'caf_parse' at src/caf_reader.c:190:17,
    inlined from 'caf_open' at src/caf_reader.c:230:9,
    inlined from 'open_input' at src/main.c:754:27,
    inlined from 'main' at src/main.c:802:19:
src/pcm_readhelper.c:231:24: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  231 |             mapping[i] = i;
      |                        ^
src/main.c: In function 'main':
src/caf_reader.c:29:13: note: at offset 0 to object 'chanmap' with size 8 declared here
   29 |     uint8_t chanmap[8];
      |             ^
```

According to a similar problem in another project (https://github.com/tarantool/tarantool/issues/5564), this warning is due to a zero-lenght array when `i`=0:
https://github.com/nu774/fdkaac/blob/347e995cfc44941f6d6dfe8d4e09362a71ea8d26/src/pcm_readhelper.c#L230-L231

Thus, this commit will use variable array explicitly to avoid this GCC warning.

---
The info below is cited from https://github.com/tarantool/tarantool/commit/8915ae203f873198caf76fbad4bf9edce76a6153

> Zero-lenght arrays are GNU C extension. There's ISO C99 flexible array member, which is preffered mechanism to declare variable-length types.
> 
> Flexible array member allows us to avoid applying sizeof operator cause it's incomplete type, so it will be an error at compile time. There're any moments else why it's better way to implement such structures via FAM:
> https://gcc.gnu.org/onlinedocs/gcc/Zero-Length.html
> 
> In this issue it fixed gcc 10 warning:
> "warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]"